### PR TITLE
Add support for inline QR codes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     ],
     "require": {
         "php": ">=5.3.7",
-        "christian-riesen/base32": "~1.0"
+        "christian-riesen/base32": "~1.0",
+        "simplesoftwareio/simple-qrcode" : "1.3.*"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.1"

--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -35,6 +35,9 @@ use PragmaRX\Google2FA\Exceptions\InvalidCharactersException;
 use PragmaRX\Google2FA\Exceptions\SecretKeyTooShortException;
 use PragmaRX\Google2FA\Contracts\Google2FA as Google2FAContract;
 
+use SimpleSoftwareIO\QrCode\BaconQrCodeGenerator;
+use BaconQrCode\Renderer\Image\Png;
+
 class Google2FA implements Google2FAContract
 {
 
@@ -258,9 +261,38 @@ class Google2FA implements Google2FAContract
 	 */
 	public function getQRCodeGoogleUrl($company, $holder, $secret)
 	{
-		$url = 'otpauth://totp/'.$company.':'.$holder.'?secret='.$secret.'&issuer='.$company.'';
+		$url = $this->getQRCodeUrl($company, $holder, $secret);
 
 		return 'https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl='.urlencode($url).'';
+	}
+
+    /**
+	 * Generates a QR code data url to display inline.
+	 *
+	 * @param $company
+	 * @param $holder
+	 * @param $secret
+	 * @return string
+	 */
+	public function getQRCodeInline($company, $holder, $secret, $size = 100)
+	{
+    	$qr = new BaconQrCodeGenerator(null, new Png);
+		$url = $this->getQRCodeUrl($company, $holder, $secret);
+
+		return 'data:image/png;base64,' . base64_encode($qr->margin(0)->size($size)->generate($url));
+	}
+
+    /**
+	 * Creates a QR code url.
+	 *
+	 * @param $company
+	 * @param $holder
+	 * @param $secret
+	 * @return string
+	 */
+	public function getQRCodeUrl($company, $holder, $secret)
+	{
+		return 'otpauth://totp/'.urlencode($company.':'.$holder).'?secret='.$secret.'&issuer='.urlencode($company).'';
 	}
 
 	/**


### PR DESCRIPTION
Adds support to display QR codes inline with data URLs, instead of using Google Charts.