### PR TITLE
Fixed broken code without the multibyte string extension

### DIFF
--- a/src/Support/Str.php
+++ b/src/Support/Str.php
@@ -31,9 +31,11 @@ class Str
             return hash_equals($knownString, $userInput);
         }
 
-        $knownLength = mb_strlen($knownString, '8bit');
+        $mb = function_exists('mb_string');
 
-        if (mb_strlen($userInput, '8bit') !== $knownLength) {
+        $knownLength = $mb ? mb_strlen($knownString, '8bit') : strlen($knownString);
+
+        if (($mb ? mb_strlen($userInput, '8bit') : strlen($userInput)) !== $knownLength) {
             return false;
         }
 


### PR DESCRIPTION
Laravel depends on the the multibyte string function, but you do not.