### PR TITLE
Add '$encoding' parameter to getQRCodeInline() to avoid CJK issues.

### DIFF
--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -268,11 +268,16 @@ class Google2FA implements Google2FAContract
 	 * @param $company
 	 * @param $holder
 	 * @param $secret
+	 * @param $size
+	 * @param $encoding Default to UTF-8
 	 * @return string
 	 */
-	public function getQRCodeInline($company, $holder, $secret, $size = 100)
+	public function getQRCodeInline($company, $holder, $secret, $size = 100, $encoding = 'utf-8')
 	{
 		$qr = new BaconQrCodeGenerator(null, new Png);
+		if ($encoding) {
+			$qr->encoding($encoding);
+		}
 		$url = $this->getQRCodeUrl($company, $holder, $secret);
 
 		return 'data:image/png;base64,' . base64_encode($qr->margin(0)->size($size)->generate($url));


### PR DESCRIPTION
If $company or $holder includes CJK(or any UTF8) character, the default encoding ISO8859-1 which used in BaconQrCodeGenerator will cause an error while it generating QR code.