### PR TITLE
Setup Travis correctly for phpspec (+ cache improvements)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,18 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
 
-before_script:
-  - curl -s http://getcomposer.org/installer | php
-  - php composer.phar install --dev
+## Cache composer
+sudo: false
 
-script: phpunit
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+install:
+  - travis_retry composer install --prefer-dist --no-interaction
+
+script: vendor/bin/phpspec run


### PR DESCRIPTION
Currently, Travis is not used the run the test. There are tests, so might as well run them :)

- Use phpspec instead of phpunit
- Add php 5.6/7.0 to build matrix
- No need anymore to install the composer phar
- use composer retry to install the composer dependencies
- Prefer dist + use the cache/sudo settings to cache the downloads from composer for faster builds.

After this, Travis still needs to be setup as hook by the author.