### PR TITLE
Use base QR code package, update contract methods

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.3.7",
         "christian-riesen/base32": "~1.0",
-        "simplesoftwareio/simple-qrcode" : "1.3.*"
+        "bacon/bacon-qr-code": "1.0.*"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.1"

--- a/src/Contracts/Google2FA.php
+++ b/src/Contracts/Google2FA.php
@@ -82,11 +82,24 @@ interface Google2FA
 	/**
 	 * Creates a Google QR code url.
 	 *
-	 * @param $company
-	 * @param $holder
-	 * @param $secret
+	 * @param string $company
+	 * @param string $holder
+	 * @param string $secret
+	 * @param integer $size
 	 * @return string
 	 */
-	public function getQRCodeGoogleUrl($company, $holder, $secret);
+	public function getQRCodeGoogleUrl($company, $holder, $secret, $size = 200);
+	
+	/**
+	 * Generates a QR code data url to display inline.
+	 *
+	 * @param string $company
+	 * @param string $holder
+	 * @param string $secret
+	 * @param integer $size
+	 * @param string $encoding Default to UTF-8
+	 * @return string
+	 */
+	public function getQRCodeInline($company, $holder, $secret, $size = 100, $encoding = 'utf-8');
 
 }

--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -277,7 +277,6 @@ class Google2FA implements Google2FAContract
 		$url = $this->getQRCodeUrl($company, $holder, $secret);
 
 		$renderer = new Png();
-		$renderer->setMargin(0);
 		$renderer->setWidth($size);
 		$renderer->setHeight($size);
 


### PR DESCRIPTION
- Use base package instead of wrapper for QR code (less dependencies, now requires on laravel support)
- Update default size to 200, don't set 0 margin, same as Google
- Add size parameter to Google URL, to match inline (default 200)
- Add inline function to contract.

Note: As the interface changes, this is a breaking change and should be tagged as a new minor version, 0.8.0 currently,