### PR TITLE
Fixes invalid barcode due to spaces.

### DIFF
--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -308,7 +308,7 @@ class Google2FA implements Google2FAContract
      */
     public function getQRCodeUrl($company, $holder, $secret)
     {
-        return 'otpauth://totp/'.$company.':'.$holder.'?secret='.$secret.'&issuer='.$company.'';
+        return 'otpauth://totp/'.rawurlencode($company).':'.$holder.'?secret='.$secret.'&issuer='.rawurlencode($company).'';
     }
 
     /**


### PR DESCRIPTION
Fixed according to format specified here:
- https://github.com/google/google-authenticator/wiki/Key-Uri-Format

Also fixes:
- https://github.com/antonioribeiro/google2fa/issues/46