### PR TITLE
fix null timestamp issue in verifyKeyNewer

### DIFF
--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -350,8 +350,10 @@ class Google2FA
      */
     public function verifyKey($secret, $key, $window = null, $timestamp = null, $oldTimestamp = '__not_set__')
     {
+        $timestamp = $this->makeTimestamp($timestamp);
+
         $startingTimestamp = $oldTimestamp === '__not_set__'
-            ? ($timestamp = $this->makeTimestamp($timestamp)) - $this->getWindow($window)
+            ? $timestamp - $this->getWindow($window)
             : max($timestamp - $this->getWindow($window), $oldTimestamp + 1);
 
         return $this->findValidOTP(


### PR DESCRIPTION
When using `verifyKeyNewer` then `$oldTimestamp` is given here.
This means that the ternary operator (`? :`) goes to the else-part and skips the then-part. But then the timestamp normalization (`$timestamp = $this->makeTimestamp($timestamp)`) is not applied, thus calling `$this->findValidOTP` with `null`.