### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "phpspec/phpspec": "~2.1",
-        "phpunit/phpunit": "~4",
+        "phpunit/phpunit": "~4.8.35",
         "bacon/bacon-qr-code": "~1.0"
     },
     "autoload": {

--- a/tests/Google2FATest.php
+++ b/tests/Google2FATest.php
@@ -2,10 +2,11 @@
 
 namespace spec\PragmaRX\Google2FA;
 
+use PHPUnit\Framework\TestCase;
 use PragmaRX\Google2FA\Google2FA;
 use PragmaRX\Google2FA\Support\Constants;
 
-class Google2FATest extends \PHPUnit_Framework_TestCase
+class Google2FATest extends TestCase
 {
     const SECRET = 'ADUMJO5634NPDEKW';
 


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCase. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.