### PR TITLE
Made all exceptions inherit from a base exception

### DIFF
--- a/src/Exceptions/Google2FAException.php
+++ b/src/Exceptions/Google2FAException.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace PragmaRX\Google2FA\Exceptions;
-
-use Exception;
-
-class Google2FAException extends Exception
-{
-}

--- a/src/Exceptions/Google2FAException.php
+++ b/src/Exceptions/Google2FAException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PragmaRX\Google2FA\Exceptions;
+
+use Exception;
+
+class Google2FAException extends Exception
+{
+}

--- a/src/Exceptions/Google2FAExceptionInterface.php
+++ b/src/Exceptions/Google2FAExceptionInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace PragmaRX\Google2FA\Exceptions;
+
+interface Google2FAExceptionInterface
+{
+
+}

--- a/src/Exceptions/IncompatibleWithGoogleAuthenticatorException.php
+++ b/src/Exceptions/IncompatibleWithGoogleAuthenticatorException.php
@@ -2,7 +2,9 @@
 
 namespace PragmaRX\Google2FA\Exceptions;
 
-class IncompatibleWithGoogleAuthenticatorException extends Google2FAException
+use Exception;
+
+class IncompatibleWithGoogleAuthenticatorException extends Exception implements Google2FAExceptionInterface
 {
     protected $message = 'This secret key is not compatible with Google Authenticator.';
 }

--- a/src/Exceptions/IncompatibleWithGoogleAuthenticatorException.php
+++ b/src/Exceptions/IncompatibleWithGoogleAuthenticatorException.php
@@ -2,9 +2,7 @@
 
 namespace PragmaRX\Google2FA\Exceptions;
 
-use Exception;
-
-class IncompatibleWithGoogleAuthenticatorException extends Exception
+class IncompatibleWithGoogleAuthenticatorException extends Google2FAException
 {
     protected $message = 'This secret key is not compatible with Google Authenticator.';
 }

--- a/src/Exceptions/InvalidCharactersException.php
+++ b/src/Exceptions/InvalidCharactersException.php
@@ -2,7 +2,9 @@
 
 namespace PragmaRX\Google2FA\Exceptions;
 
-class InvalidCharactersException extends Google2FAException
+use Exception;
+
+class InvalidCharactersException extends Exception implements Google2FAExceptionInterface
 {
     protected $message = 'Invalid characters in the base32 string.';
 }

--- a/src/Exceptions/InvalidCharactersException.php
+++ b/src/Exceptions/InvalidCharactersException.php
@@ -2,9 +2,7 @@
 
 namespace PragmaRX\Google2FA\Exceptions;
 
-use Exception;
-
-class InvalidCharactersException extends Exception
+class InvalidCharactersException extends Google2FAException
 {
     protected $message = 'Invalid characters in the base32 string.';
 }

--- a/src/Exceptions/SecretKeyTooShortException.php
+++ b/src/Exceptions/SecretKeyTooShortException.php
@@ -2,7 +2,9 @@
 
 namespace PragmaRX\Google2FA\Exceptions;
 
-class SecretKeyTooShortException extends Google2FAException
+use Exception;
+
+class SecretKeyTooShortException extends Exception implements Google2FAExceptionInterface
 {
     protected $message = 'Secret key is too short. Must be at least 16 base32 characters';
 }

--- a/src/Exceptions/SecretKeyTooShortException.php
+++ b/src/Exceptions/SecretKeyTooShortException.php
@@ -2,9 +2,7 @@
 
 namespace PragmaRX\Google2FA\Exceptions;
 
-use Exception;
-
-class SecretKeyTooShortException extends Exception
+class SecretKeyTooShortException extends Google2FAException
 {
     protected $message = 'Secret key is too short. Must be at least 16 base32 characters';
 }

--- a/tests/Google2FATest.php
+++ b/tests/Google2FATest.php
@@ -3,7 +3,7 @@
 namespace PragmaRX\Google2FA\Tests;
 
 use PHPUnit\Framework\TestCase;
-use PragmaRX\Google2FA\Exceptions\Google2FAException;
+use PragmaRX\Google2FA\Exceptions\Google2FAExceptionInterface;
 use PragmaRX\Google2FA\Google2FA;
 use PragmaRX\Google2FA\Support\Constants as Google2FAConstants;
 
@@ -57,7 +57,7 @@ class Google2FATest extends TestCase
             $this->google2fa
                 ->setEnforceGoogleAuthenticatorCompatibility(true)
                 ->generateSecretKey(17);
-        } catch (Google2FAException $exception) {
+        } catch (Google2FAExceptionInterface $exception) {
             $this->assertInstanceOf('PragmaRX\Google2FA\Exceptions\IncompatibleWithGoogleAuthenticatorException',
                 $exception);
         }
@@ -422,7 +422,7 @@ class Google2FATest extends TestCase
                 null,
                 26213400
             );
-        } catch (Google2FAException $exception) {
+        } catch (Google2FAExceptionInterface $exception) {
             $this->assertInstanceOf('PragmaRX\Google2FA\Exceptions\SecretKeyTooShortException', $exception);
         }
     }
@@ -437,7 +437,7 @@ class Google2FATest extends TestCase
 
         try {
             $this->google2fa->getCurrentOtp(Constants::INVALID_SECRET);
-        } catch (Google2FAException $exception) {
+        } catch (Google2FAExceptionInterface $exception) {
             $this->assertInstanceOf('PragmaRX\Google2FA\Exceptions\InvalidCharactersException', $exception);
         }
     }

--- a/tests/Google2FATest.php
+++ b/tests/Google2FATest.php
@@ -3,6 +3,7 @@
 namespace PragmaRX\Google2FA\Tests;
 
 use PHPUnit\Framework\TestCase;
+use PragmaRX\Google2FA\Exceptions\Google2FAException;
 use PragmaRX\Google2FA\Google2FA;
 use PragmaRX\Google2FA\Support\Constants as Google2FAConstants;
 
@@ -50,23 +51,16 @@ class Google2FATest extends TestCase
         );
     }
 
-    /**
-     * @expectedException  \PragmaRX\Google2FA\Exceptions\IncompatibleWithGoogleAuthenticatorException
-     */
     public function testGeneratesASecretKeysCompatibleWithGoogleAuthenticatorOrNot()
     {
-        $this->google2fa
-            ->setEnforceGoogleAuthenticatorCompatibility(true)
-            ->generateSecretKey(17);
-
-        $this->assertEquals(
-            17,
-            strlen(
-                $this->google2fa
-                    ->setEnforceGoogleAuthenticatorCompatibility(false)
-                    ->generateSecretKey(17)
-            )
-        );
+        try {
+            $this->google2fa
+                ->setEnforceGoogleAuthenticatorCompatibility(true)
+                ->generateSecretKey(17);
+        } catch (Google2FAException $exception) {
+            $this->assertInstanceOf('PragmaRX\Google2FA\Exceptions\IncompatibleWithGoogleAuthenticatorException',
+                $exception);
+        }
     }
 
     public function testConvertsInvalidCharsToBase32()
@@ -417,24 +411,22 @@ class Google2FATest extends TestCase
         );
     }
 
-    /**
-     * @expectedException  \PragmaRX\Google2FA\Exceptions\SecretKeyTooShortException
-     */
     public function testShortSecretKey()
     {
         $this->google2fa->setEnforceGoogleAuthenticatorCompatibility(false);
 
-        $this->google2fa->verifyKey(
-            Constants::SHORT_SECRET,
-            '558854',
-            null,
-            26213400
-        );
+        try {
+            $this->google2fa->verifyKey(
+                Constants::SHORT_SECRET,
+                '558854',
+                null,
+                26213400
+            );
+        } catch (Google2FAException $exception) {
+            $this->assertInstanceOf('PragmaRX\Google2FA\Exceptions\SecretKeyTooShortException', $exception);
+        }
     }
 
-    /**
-     * @expectedException  \PragmaRX\Google2FA\Exceptions\InvalidCharactersException
-     */
     public function testValidateKey()
     {
         $this->assertTrue(
@@ -443,6 +435,10 @@ class Google2FATest extends TestCase
 
         $this->google2fa->setEnforceGoogleAuthenticatorCompatibility(false);
 
-        $this->google2fa->getCurrentOtp(Constants::INVALID_SECRET);
+        try {
+            $this->google2fa->getCurrentOtp(Constants::INVALID_SECRET);
+        } catch (Google2FAException $exception) {
+            $this->assertInstanceOf('PragmaRX\Google2FA\Exceptions\InvalidCharactersException', $exception);
+        }
     }
 }


### PR DESCRIPTION
Implements changes proposed in #115.

> Currently you have to catch every single exception this package throws. If you make a generic exception, say `Google2FAException` and have all other exceptions extend this one it is much easier for consumers of this package to catch anything thrown by it. Sometimes you don't care exactly what exception was thrown but you'd like to identify the general area (or package) of the problem.

### Changes in tests:

Unit tests used the `@expectedException` to test for exceptions. There is nothing wrong with this approach except that we now want to test two things: 

1) That the exception is a subclass of `Google2FAException`
2) That the exception is an instance of each particular exception.

In order to achieve both, I wrapped the test calls in a try/catch block which catches with the generalized exception, and then checks for the specific exception. 