### PR TITLE
Removed legacy PHPUnit configuration

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,6 @@
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
-         syntaxCheck="true"
          verbose="true"
 >
     <testsuites>


### PR DESCRIPTION
When running the test suites I was getting the following error:

```
  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 15:
  - Element 'phpunit', attribute 'syntaxCheck': The attribute 'syntaxCheck' is not allowed.

  Test results may not be as expected.
```

According to the PHPUnit's author (https://stackoverflow.com/a/44331140/255260

>That configuration setting has not had an effect in years. It was removed long ago.