### PR TITLE
Update to support PHP 8.1

### DIFF
--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -77,7 +77,7 @@ class Google2FA
             $startingTimestamp++
         ) {
             if (
-                hash_equals($this->oathTotp($secret, $startingTimestamp), $key)
+                hash_equals($this->oathTotp($secret, $startingTimestamp), (string) $key)
             ) {
                 return is_null($oldTimestamp)
                     ? true


### PR DESCRIPTION
Added string cast to the hash_equals function in order to work for the latest PHP Version.