### PR TITLE
Upgrade PHPStan to the latest version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5.15|^8.5|^9.0",
-        "phpstan/phpstan": "^0.12.18"
+        "phpstan/phpstan": "^1.9"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
When running `composer analyse`, the old PHPStan throws a lot of "deprecated" errors on PHP 8.2, the upgrade fixes them.

Even PHPStan 0.12.100 itself says
```
⚠️  You're running a really old version of PHPStan.️

The last release in the 0.12.x series with new features
and bugfixes was released on September 12th 2021,
that's 513 days ago.

Since then more than 67 new PHPStan versions were released
with hundreds of new features, bugfixes, and other
quality of life improvements.

To learn about what you're missing out on, check out
this blog with articles about the latest major releases:
https://phpstan.org/blog

Upgrade today to PHPStan 1.8 or newer by using
"phpstan/phpstan": "^1.8" in your composer.json.
```