### PR TITLE
Add `\SensitiveParameter` attribute to params with any secret or key material

### DIFF
--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -65,7 +65,9 @@ class Google2FA
      * @return bool|int
      */
     public function findValidOTP(
+        #[\SensitiveParameter]
         $secret,
+        #[\SensitiveParameter]
         $key,
         $window,
         $startingTimestamp,
@@ -96,8 +98,11 @@ class Google2FA
      *
      * @return string
      */
-    protected function generateHotp($secret, $counter)
-    {
+    protected function generateHotp(
+        #[\SensitiveParameter]
+        $secret,
+        $counter
+    ) {
         return hash_hmac(
             $this->getAlgorithm(),
             pack('N*', 0, $counter), // Counter must be 64-bit int
@@ -134,8 +139,10 @@ class Google2FA
      *
      * @return string
      */
-    public function getCurrentOtp($secret)
-    {
+    public function getCurrentOtp(
+        #[\SensitiveParameter]
+        $secret
+    ) {
         return $this->oathTotp($secret, $this->getTimestamp());
     }
 
@@ -176,8 +183,10 @@ class Google2FA
      *
      * @return string
      */
-    public function getSecret($secret = null)
-    {
+    public function getSecret(
+        #[\SensitiveParameter]
+        $secret = null
+    ) {
         return is_null($secret) ? $this->secret : $secret;
     }
 
@@ -263,8 +272,11 @@ class Google2FA
      *
      * @return string
      */
-    public function oathTotp($secret, $counter)
-    {
+    public function oathTotp(
+        #[\SensitiveParameter]
+        $secret,
+        $counter
+    ) {
         if (strlen($secret) < 8) {
             throw new SecretKeyTooShortException();
         }
@@ -286,8 +298,10 @@ class Google2FA
      *
      * @return string
      **/
-    public function oathTruncate($hash)
-    {
+    public function oathTruncate(
+        #[\SensitiveParameter]
+        $hash
+    ) {
         $offset = ord($hash[strlen($hash) - 1]) & 0xF;
 
         $temp = unpack('N', substr($hash, $offset, 4));
@@ -377,8 +391,10 @@ class Google2FA
      *
      * @param mixed $secret
      */
-    public function setSecret($secret)
-    {
+    public function setSecret(
+        #[\SensitiveParameter]
+        $secret,
+    ) {
         $this->secret = $secret;
     }
 
@@ -409,7 +425,9 @@ class Google2FA
      * @return bool|int
      */
     public function verify(
+        #[\SensitiveParameter]
         $key,
+        #[\SensitiveParameter]
         $secret,
         $window = null,
         $timestamp = null,
@@ -441,7 +459,9 @@ class Google2FA
      * @return bool|int
      */
     public function verifyKey(
+        #[\SensitiveParameter]
         $secret,
+        #[\SensitiveParameter]
         $key,
         $window = null,
         $timestamp = null,
@@ -478,7 +498,9 @@ class Google2FA
      * @return bool|int
      */
     public function verifyKeyNewer(
+        #[\SensitiveParameter]
         $secret,
+        #[\SensitiveParameter]
         $key,
         $oldTimestamp,
         $window = null,

--- a/src/Support/Base32.php
+++ b/src/Support/Base32.php
@@ -21,8 +21,10 @@ trait Base32
      *
      * @return int
      */
-    protected function charCountBits($b32)
-    {
+    protected function charCountBits(
+        #[\SensitiveParameter]
+        $b32
+    ) {
         return strlen($b32) * 8;
     }
 
@@ -39,8 +41,11 @@ trait Base32
      *
      * @return string
      */
-    public function generateBase32RandomKey($length = 16, $prefix = '')
-    {
+    public function generateBase32RandomKey(
+        $length = 16,
+        #[\SensitiveParameter]
+        $prefix = ''
+    ) {
         $secret = $prefix ? $this->toBase32($prefix) : '';
 
         $secret = $this->strPadBase32($secret, $length);
@@ -61,8 +66,10 @@ trait Base32
      *
      * @return string
      */
-    public function base32Decode($b32)
-    {
+    public function base32Decode(
+        #[\SensitiveParameter]
+        $b32
+    ) {
         $b32 = strtoupper($b32);
 
         $this->validateSecret($b32);
@@ -77,8 +84,10 @@ trait Base32
      *
      * @return bool
      */
-    protected function isCharCountNotAPowerOfTwo($b32)
-    {
+    protected function isCharCountNotAPowerOfTwo(
+        #[\SensitiveParameter]
+        $b32
+    ) {
         return (strlen($b32) & (strlen($b32) - 1)) !== 0;
     }
 
@@ -92,8 +101,11 @@ trait Base32
      *
      * @return string
      */
-    private function strPadBase32($string, $length)
-    {
+    private function strPadBase32(
+        #[\SensitiveParameter]
+        $string,
+        $length
+    ) {
         for ($i = 0; $i < $length; $i++) {
             $string .= substr(
                 Constants::VALID_FOR_B32_SCRAMBLED,
@@ -112,8 +124,10 @@ trait Base32
      *
      * @return string
      */
-    public function toBase32($string)
-    {
+    public function toBase32(
+        #[\SensitiveParameter]
+        $string
+    ) {
         $encoded = ParagonieBase32::encodeUpper($string);
 
         return str_replace('=', '', $encoded);
@@ -143,8 +157,10 @@ trait Base32
      * @throws \PragmaRX\Google2FA\Exceptions\SecretKeyTooShortException
      * @throws \PragmaRX\Google2FA\Exceptions\IncompatibleWithGoogleAuthenticatorException
      */
-    protected function validateSecret($b32)
-    {
+    protected function validateSecret(
+        #[\SensitiveParameter]
+        $b32
+    ) {
         $this->checkForValidCharacters($b32);
 
         $this->checkGoogleAuthenticatorCompatibility($b32);
@@ -159,8 +175,10 @@ trait Base32
      *
      * @throws IncompatibleWithGoogleAuthenticatorException
      */
-    protected function checkGoogleAuthenticatorCompatibility($b32)
-    {
+    protected function checkGoogleAuthenticatorCompatibility(
+        #[\SensitiveParameter]
+        $b32
+    ) {
         if (
             $this->enforceGoogleAuthenticatorCompatibility &&
             $this->isCharCountNotAPowerOfTwo($b32) // Google Authenticator requires it to be a power of 2 base32 length string
@@ -176,8 +194,10 @@ trait Base32
      *
      * @throws \PragmaRX\Google2FA\Exceptions\InvalidCharactersException
      */
-    protected function checkForValidCharacters($b32)
-    {
+    protected function checkForValidCharacters(
+        #[\SensitiveParameter]
+        $b32
+    ) {
         if (
             preg_replace('/[^'.Constants::VALID_FOR_B32.']/', '', $b32) !==
             $b32
@@ -193,8 +213,10 @@ trait Base32
      *
      * @throws \PragmaRX\Google2FA\Exceptions\SecretKeyTooShortException
      */
-    protected function checkIsBigEnough($b32)
-    {
+    protected function checkIsBigEnough(
+        #[\SensitiveParameter]
+        $b32
+    ) {
         // Minimum = 128 bits
         // Recommended = 160 bits
         // Compatible with Google Authenticator = 256 bits

--- a/src/Support/QRCode.php
+++ b/src/Support/QRCode.php
@@ -13,8 +13,12 @@ trait QRCode
      *
      * @return string
      */
-    public function getQRCodeUrl($company, $holder, $secret)
-    {
+    public function getQRCodeUrl(
+        $company,
+        $holder,
+        #[\SensitiveParameter]
+        $secret
+    ) {
         return 'otpauth://totp/'.
             rawurlencode($company).
             ':'.


### PR DESCRIPTION
Hi, this attribute is used to mark a parameter that is sensitive and should have its value redacted if present in a stack trace. (verbatim copy from the [PHP manual](https://www.php.net/manual/en/class.sensitiveparameter.php))

The redaction will be performed only on PHP 8.2 and newer but the attribute itself and the syntax is backwards compatible so using the class with let's say PHP 7.4 will still work as it did before.

I have added the attribute to all params that hold the secret, or the 2FA code, or strings that will contain parts of either of them.

Compare the call stacks, before:
![before](https://user-images.githubusercontent.com/1966648/217379948-dd968b16-68a9-45bd-8399-9ab9849eebac.png)
and after the attribute has been added:
![after](https://user-images.githubusercontent.com/1966648/217379974-ed12a1c4-1473-48e8-95b8-9d7808c3635f.png)

Thanks.