### PR TITLE
PHPStan CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,6 +2,7 @@ name: Run tests
 
 on:
   push:
+  pull_request:
   schedule:
     - cron: '0 0 * * *'
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,3 +29,6 @@ jobs:
 
       - name: Execute tests
         run: vendor/bin/phpunit
+
+      - name: Execute PHPStan
+        run: vendor/bin/phpstan analyse -c phpstan.neon

--- a/tests/Google2FATest.php
+++ b/tests/Google2FATest.php
@@ -832,7 +832,7 @@ class Google2FATest extends TestCase
     {
         $this->expectException(\PragmaRX\Google2FA\Exceptions\SecretKeyTooShortException::class);
 
-        $this->google2fa->verify('558854', null, null, 26213400);
+        $this->google2fa->verify('558854', '', null, 26213400);
     }
 
     public function testThrowsSecretKeyTooShortExceptionContract()
@@ -881,6 +881,6 @@ class Google2FATest extends TestCase
     {
         $this->expectException(\PragmaRX\Google2FA\Exceptions\SecretKeyTooShortException::class);
 
-        $this->google2fa->oathTotp(null, null);
+        $this->google2fa->oathTotp('', 0);
     }
 }


### PR DESCRIPTION
- Fix errors reported by PHPStan (nulls instead of strings & ints in a test file)
- Run PHPStan in CI
- ... and on PRs

I'd also recommend protecting the default branch in repo settings and making the tests required before a PR can be merged.