### PR TITLE
PHPStan level 9 with bleeding edge

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,3 +4,6 @@ parameters:
     - tests
 
   level: max
+
+includes:
+  - phar://phpstan.phar/conf/bleedingEdge.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,4 +3,4 @@ parameters:
     - src
     - tests
 
-  level: 8
+  level: max

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,4 +3,4 @@ parameters:
     - src
     - tests
 
-  level: 5
+  level: 6

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,4 +3,4 @@ parameters:
     - src
     - tests
 
-  level: 6
+  level: 8

--- a/src/Exceptions/Contracts/InvalidHash.php
+++ b/src/Exceptions/Contracts/InvalidHash.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PragmaRX\Google2FA\Exceptions\Contracts;
+
+use Throwable;
+
+interface InvalidHash extends Throwable
+{
+}

--- a/src/Exceptions/IncompatibleWithGoogleAuthenticatorException.php
+++ b/src/Exceptions/IncompatibleWithGoogleAuthenticatorException.php
@@ -7,5 +7,6 @@ use PragmaRX\Google2FA\Exceptions\Contracts\IncompatibleWithGoogleAuthenticator 
 
 class IncompatibleWithGoogleAuthenticatorException extends Google2FAException implements Google2FAExceptionContract, IncompatibleWithGoogleAuthenticatorExceptionContract
 {
+    /** @var string */
     protected $message = 'This secret key is not compatible with Google Authenticator.';
 }

--- a/src/Exceptions/InvalidAlgorithmException.php
+++ b/src/Exceptions/InvalidAlgorithmException.php
@@ -7,5 +7,6 @@ use PragmaRX\Google2FA\Exceptions\Contracts\InvalidAlgorithm as InvalidAlgorithm
 
 class InvalidAlgorithmException extends Google2FAException implements Google2FAExceptionContract, InvalidAlgorithmExceptionContract
 {
+    /** @var string */
     protected $message = 'Invalid HMAC algorithm.';
 }

--- a/src/Exceptions/InvalidCharactersException.php
+++ b/src/Exceptions/InvalidCharactersException.php
@@ -7,5 +7,6 @@ use PragmaRX\Google2FA\Exceptions\Contracts\InvalidCharacters as InvalidCharacte
 
 class InvalidCharactersException extends Google2FAException implements Google2FAExceptionContract, InvalidCharactersExceptionContract
 {
+    /** @var string */
     protected $message = 'Invalid characters in the base32 string.';
 }

--- a/src/Exceptions/InvalidHashException.php
+++ b/src/Exceptions/InvalidHashException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace PragmaRX\Google2FA\Exceptions;
+
+use PragmaRX\Google2FA\Exceptions\Contracts\Google2FA as Google2FAExceptionContract;
+use PragmaRX\Google2FA\Exceptions\Contracts\InvalidHash as InvalidHashExceptionContract;
+use Throwable;
+
+class InvalidHashException extends Google2FAException implements Google2FAExceptionContract, InvalidHashExceptionContract
+{
+    public function __construct(string $message = '', int $code = 0, ?Throwable $previous = null)
+    {
+        $error = 'Invalid hash to unpack';
+        if ($message !== '') {
+            $error .= ': '.$message;
+        }
+        parent::__construct($error, $code, $previous);
+    }
+}

--- a/src/Exceptions/SecretKeyTooShortException.php
+++ b/src/Exceptions/SecretKeyTooShortException.php
@@ -7,5 +7,6 @@ use PragmaRX\Google2FA\Exceptions\Contracts\SecretKeyTooShort as SecretKeyTooSho
 
 class SecretKeyTooShortException extends Google2FAException implements Google2FAExceptionContract, SecretKeyTooShortExceptionContract
 {
+    /** @var string */
     protected $message = 'Secret key is too short. Must be at least 16 base32 characters';
 }

--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -204,9 +204,9 @@ class Google2FA
     /**
      * Get a list of valid HMAC algorithms.
      *
-     * @return array
+     * @return list<string>
      */
-    protected function getValidAlgorithms()
+    protected function getValidAlgorithms(): array
     {
         return [
             Constants::SHA1,
@@ -371,7 +371,7 @@ class Google2FA
      *
      * @param mixed $keyRegeneration
      */
-    public function setKeyRegeneration($keyRegeneration)
+    public function setKeyRegeneration($keyRegeneration): void
     {
         $this->keyRegeneration = $keyRegeneration;
     }
@@ -381,7 +381,7 @@ class Google2FA
      *
      * @param mixed $oneTimePasswordLength
      */
-    public function setOneTimePasswordLength($oneTimePasswordLength)
+    public function setOneTimePasswordLength($oneTimePasswordLength): void
     {
         $this->oneTimePasswordLength = $oneTimePasswordLength;
     }
@@ -394,7 +394,7 @@ class Google2FA
     public function setSecret(
         #[\SensitiveParameter]
         $secret
-    ) {
+    ): void {
         $this->secret = $secret;
     }
 
@@ -403,7 +403,7 @@ class Google2FA
      *
      * @param mixed $window
      */
-    public function setWindow($window)
+    public function setWindow($window): void
     {
         $this->window = $window;
     }

--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -235,9 +235,9 @@ class Google2FA
      * @param int      $timestamp
      * @param int|null $oldTimestamp
      *
-     * @return mixed
+     * @return int
      */
-    private function makeStartingTimestamp($window, $timestamp, $oldTimestamp = null)
+    private function makeStartingTimestamp($window, $timestamp, $oldTimestamp = null): int
     {
         return is_null($oldTimestamp)
             ? $timestamp - $this->getWindow($window)
@@ -341,12 +341,12 @@ class Google2FA
     /**
      * Setter for the enforce Google Authenticator compatibility property.
      *
-     * @param mixed $enforceGoogleAuthenticatorCompatibility
+     * @param bool $enforceGoogleAuthenticatorCompatibility
      *
      * @return $this
      */
     public function setEnforceGoogleAuthenticatorCompatibility(
-        $enforceGoogleAuthenticatorCompatibility
+        bool $enforceGoogleAuthenticatorCompatibility
     ) {
         $this->enforceGoogleAuthenticatorCompatibility = $enforceGoogleAuthenticatorCompatibility;
 
@@ -356,13 +356,13 @@ class Google2FA
     /**
      * Set the HMAC hashing algorithm.
      *
-     * @param mixed $algorithm
+     * @param string $algorithm
      *
      * @throws \PragmaRX\Google2FA\Exceptions\InvalidAlgorithmException
      *
      * @return \PragmaRX\Google2FA\Google2FA
      */
-    public function setAlgorithm($algorithm)
+    public function setAlgorithm(string $algorithm)
     {
         // Default to SHA1 HMAC algorithm
         if (!in_array($algorithm, $this->getValidAlgorithms())) {
@@ -377,9 +377,9 @@ class Google2FA
     /**
      * Set key regeneration.
      *
-     * @param mixed $keyRegeneration
+     * @param int $keyRegeneration
      */
-    public function setKeyRegeneration($keyRegeneration): void
+    public function setKeyRegeneration(int $keyRegeneration): void
     {
         $this->keyRegeneration = $keyRegeneration;
     }
@@ -387,9 +387,9 @@ class Google2FA
     /**
      * Set OTP length.
      *
-     * @param mixed $oneTimePasswordLength
+     * @param int $oneTimePasswordLength
      */
-    public function setOneTimePasswordLength($oneTimePasswordLength): void
+    public function setOneTimePasswordLength(int $oneTimePasswordLength): void
     {
         $this->oneTimePasswordLength = $oneTimePasswordLength;
     }
@@ -397,11 +397,11 @@ class Google2FA
     /**
      * Set secret.
      *
-     * @param mixed $secret
+     * @param string $secret
      */
     public function setSecret(
         #[\SensitiveParameter]
-        $secret
+        string $secret
     ): void {
         $this->secret = $secret;
     }
@@ -409,9 +409,9 @@ class Google2FA
     /**
      * Set the OTP window.
      *
-     * @param mixed $window
+     * @param int $window
      */
-    public function setWindow($window): void
+    public function setWindow(int $window): void
     {
         $this->window = $window;
     }

--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -3,6 +3,7 @@
 namespace PragmaRX\Google2FA;
 
 use PragmaRX\Google2FA\Exceptions\InvalidAlgorithmException;
+use PragmaRX\Google2FA\Exceptions\InvalidHashException;
 use PragmaRX\Google2FA\Exceptions\SecretKeyTooShortException;
 use PragmaRX\Google2FA\Support\Base32;
 use PragmaRX\Google2FA\Support\Constants;
@@ -296,6 +297,8 @@ class Google2FA
      *
      * @param string $hash
      *
+     * @throws \PragmaRX\Google2FA\Exceptions\InvalidHashException
+     *
      * @return string
      **/
     public function oathTruncate(
@@ -304,7 +307,12 @@ class Google2FA
     ) {
         $offset = ord($hash[strlen($hash) - 1]) & 0xF;
 
-        $temp = unpack('N', substr($hash, $offset, 4));
+        $temp = @unpack('N', substr($hash, $offset, 4)); // Intentionally @ - error converted to an exception
+        if ($temp === false) {
+            $lastError = error_get_last();
+
+            throw new InvalidHashException($lastError !== null ? $lastError['message'] : '');
+        }
 
         $temp = $temp[1] & 0x7FFFFFFF;
 

--- a/src/Support/Base32.php
+++ b/src/Support/Base32.php
@@ -11,6 +11,8 @@ trait Base32
 {
     /**
      * Enforce Google Authenticator compatibility.
+     *
+     * @var bool
      */
     protected $enforceGoogleAuthenticatorCompatibility = true;
 
@@ -160,7 +162,7 @@ trait Base32
     protected function validateSecret(
         #[\SensitiveParameter]
         $b32
-    ) {
+    ): void {
         $this->checkForValidCharacters($b32);
 
         $this->checkGoogleAuthenticatorCompatibility($b32);
@@ -178,7 +180,7 @@ trait Base32
     protected function checkGoogleAuthenticatorCompatibility(
         #[\SensitiveParameter]
         $b32
-    ) {
+    ): void {
         if (
             $this->enforceGoogleAuthenticatorCompatibility &&
             $this->isCharCountNotAPowerOfTwo($b32) // Google Authenticator requires it to be a power of 2 base32 length string
@@ -197,7 +199,7 @@ trait Base32
     protected function checkForValidCharacters(
         #[\SensitiveParameter]
         $b32
-    ) {
+    ): void {
         if (
             preg_replace('/[^'.Constants::VALID_FOR_B32.']/', '', $b32) !==
             $b32
@@ -216,7 +218,7 @@ trait Base32
     protected function checkIsBigEnough(
         #[\SensitiveParameter]
         $b32
-    ) {
+    ): void {
         // Minimum = 128 bits
         // Recommended = 160 bits
         // Compatible with Google Authenticator = 256 bits

--- a/tests/Google2FATest.php
+++ b/tests/Google2FATest.php
@@ -18,7 +18,7 @@ class Google2FATest extends TestCase
         $this->google2fa = new Google2FA();
     }
 
-    public function testIsInitializable()
+    public function testIsInitializable(): void
     {
         $this->assertInstanceOf(
             Google2FA::class,
@@ -26,7 +26,7 @@ class Google2FATest extends TestCase
         );
     }
 
-    public function testGeneratesAValidSecretKey()
+    public function testGeneratesAValidSecretKey(): void
     {
         $this->assertEquals(16, strlen($this->google2fa->generateSecretKey()));
 
@@ -55,7 +55,7 @@ class Google2FATest extends TestCase
         );
     }
 
-    public function testGeneratesASecretKeysCompatibleWithGoogleAuthenticator()
+    public function testGeneratesASecretKeysCompatibleWithGoogleAuthenticator(): void
     {
         $this->assertEquals($size = 16, strlen($this->google2fa->setEnforceGoogleAuthenticatorCompatibility(true)->generateSecretKey($size)));  /// minimum = 128 bits
         $this->assertEquals($size = 20, strlen($this->google2fa->setEnforceGoogleAuthenticatorCompatibility(false)->generateSecretKey($size))); /// recommended = 160 bits - not compatible
@@ -64,7 +64,7 @@ class Google2FATest extends TestCase
         $this->assertEquals($size = 128, strlen($this->google2fa->setEnforceGoogleAuthenticatorCompatibility(true)->generateSecretKey($size)));
     }
 
-    public function testGeneratesASecretKeysGenerationSize()
+    public function testGeneratesASecretKeysGenerationSize(): void
     {
         // 128 bits are allowed
         $this->assertEquals($size = 16, strlen($this->google2fa->generateSecretKey($size)));  /// minimum = 128 bits
@@ -77,7 +77,7 @@ class Google2FATest extends TestCase
         $this->assertEquals($size = 8, strlen($this->google2fa->generateSecretKey($size)));  /// minimum = 128 bits
     }
 
-    public function testGeneratesASecretKeysNotCompatibleWithGoogleAuthenticator()
+    public function testGeneratesASecretKeysNotCompatibleWithGoogleAuthenticator(): void
     {
         $this->expectException(\PragmaRX\Google2FA\Exceptions\IncompatibleWithGoogleAuthenticatorException::class);
         $this->assertEquals($size = 15, strlen($this->google2fa->setEnforceGoogleAuthenticatorCompatibility(true)->generateSecretKey($size)));
@@ -89,7 +89,7 @@ class Google2FATest extends TestCase
         $this->assertEquals($size = 21, strlen($this->google2fa->setEnforceGoogleAuthenticatorCompatibility(true)->generateSecretKey($size)));
     }
 
-    public function testConvertsInvalidCharsToBase32()
+    public function testConvertsInvalidCharsToBase32(): void
     {
         $converted = $this->google2fa->generateBase32RandomKey(
             16,
@@ -111,7 +111,7 @@ class Google2FATest extends TestCase
         $this->assertEquals($converted, $valid);
     }
 
-    public function testGetsValidTimestamps()
+    public function testGetsValidTimestamps(): void
     {
         $ts = $this->google2fa->getTimestamp();
 
@@ -120,7 +120,7 @@ class Google2FATest extends TestCase
         $this->assertGreaterThanOrEqual(~PHP_INT_MAX, $ts);
     }
 
-    public function testDecodesBase32Strings()
+    public function testDecodesBase32Strings(): void
     {
         $result =
             chr(0).
@@ -140,7 +140,7 @@ class Google2FATest extends TestCase
         );
     }
 
-    public function testCreatesAOneTimePassword()
+    public function testCreatesAOneTimePassword(): void
     {
         $this->assertEquals(
             6,
@@ -148,7 +148,7 @@ class Google2FATest extends TestCase
         );
     }
 
-    public function testVerifiesKeys()
+    public function testVerifiesKeys(): void
     {
         // $ts 26213400 with KEY_REGENERATION 30 seconds is
         // timestamp 786402000, which is 1994-12-02 21:00:00 UTC
@@ -212,7 +212,7 @@ class Google2FATest extends TestCase
         ); // 26213397
     }
 
-    public function testVerifiesKeysNewer()
+    public function testVerifiesKeysNewer(): void
     {
         $this->assertFalse(
             $this->google2fa->verifyKeyNewer(
@@ -309,7 +309,7 @@ class Google2FATest extends TestCase
         ); // 26213403
     }
 
-    public function testVerifiesSha256Keys()
+    public function testVerifiesSha256Keys(): void
     {
         // $ts 26213400 with KEY_REGENERATION 30 seconds is
         // timestamp 786402000, which is 1994-12-02 21:00:00 UTC
@@ -380,7 +380,7 @@ class Google2FATest extends TestCase
         ); // 26213397
     }
 
-    public function testVerifiesSha256KeysNewer()
+    public function testVerifiesSha256KeysNewer(): void
     {
         $this->google2fa->setAlgorithm(Google2FAConstants::SHA256);
 
@@ -463,7 +463,7 @@ class Google2FATest extends TestCase
         ); // 26213403
     }
 
-    public function testVerifiesSha512Keys()
+    public function testVerifiesSha512Keys(): void
     {
         // $ts 26213400 with KEY_REGENERATION 30 seconds is
         // timestamp 786402000, which is 1994-12-02 21:00:00 UTC
@@ -529,7 +529,7 @@ class Google2FATest extends TestCase
         ); // 26213397
     }
 
-    public function testVerifiesSha512KeysNewer()
+    public function testVerifiesSha512KeysNewer(): void
     {
         $this->google2fa->setAlgorithm(Google2FAConstants::SHA512);
 
@@ -612,7 +612,7 @@ class Google2FATest extends TestCase
         ); // 26213403
     }
 
-    public function testRemovesInvalidCharsFromSecret()
+    public function testRemovesInvalidCharsFromSecret(): void
     {
         $this->assertEquals(
             Constants::SECRET,
@@ -620,7 +620,7 @@ class Google2FATest extends TestCase
         );
     }
 
-    public function testConvertsToBase32()
+    public function testConvertsToBase32(): void
     {
         $this->assertEquals(
             'KBZGCZ3NMFJFQ',
@@ -628,7 +628,7 @@ class Google2FATest extends TestCase
         );
     }
 
-    public function testSetsTheWindow()
+    public function testSetsTheWindow(): void
     {
         $this->google2fa->setWindow(6);
 
@@ -691,7 +691,7 @@ class Google2FATest extends TestCase
         );
     }
 
-    public function testSetsTheSecret()
+    public function testSetsTheSecret(): void
     {
         $this->assertFalse(
             $this->google2fa->verify('558854', Constants::WRONG_SECRET)
@@ -711,7 +711,7 @@ class Google2FATest extends TestCase
         $this->google2fa->setSecret(Constants::SECRET);
     }
 
-    public function testGetsAlgorithm()
+    public function testGetsAlgorithm(): void
     {
         $this->google2fa->setAlgorithm('sha1');
 
@@ -729,7 +729,7 @@ class Google2FATest extends TestCase
         $this->assertEquals(Google2FAConstants::SHA512, $this->google2fa->getAlgorithm());
     }
 
-    public function testSetWrongAlgorithm()
+    public function testSetWrongAlgorithm(): void
     {
         $this->expectException(\PragmaRX\Google2FA\Exceptions\InvalidAlgorithmException::class);
 
@@ -739,21 +739,21 @@ class Google2FATest extends TestCase
         $this->assertEquals(Google2FAConstants::SHA1, $this->google2fa->getAlgorithm());
     }
 
-    public function testGetsKeyRegeneration()
+    public function testGetsKeyRegeneration(): void
     {
         $this->google2fa->setKeyRegeneration(11);
 
         $this->assertEquals(11, $this->google2fa->getKeyRegeneration());
     }
 
-    public function testGetsOtpLength()
+    public function testGetsOtpLength(): void
     {
         $this->google2fa->setOneTimePasswordLength(7);
 
         $this->assertEquals(7, $this->google2fa->getOneTimePasswordLength());
     }
 
-    public function testGeneratesPasswordsInManyDifferentSizes()
+    public function testGeneratesPasswordsInManyDifferentSizes(): void
     {
         $this->google2fa->setWindow(2);
 
@@ -780,7 +780,7 @@ class Google2FATest extends TestCase
         );
     }
 
-    public function testShortSecretKey()
+    public function testShortSecretKey(): void
     {
         $this->expectException(\PragmaRX\Google2FA\Exceptions\SecretKeyTooShortException::class);
 
@@ -794,7 +794,7 @@ class Google2FATest extends TestCase
         );
     }
 
-    public function testValidateKey()
+    public function testValidateKey(): void
     {
         $this->expectException(\PragmaRX\Google2FA\Exceptions\InvalidCharactersException::class);
 
@@ -807,49 +807,49 @@ class Google2FATest extends TestCase
         $this->google2fa->getCurrentOtp(Constants::INVALID_SECRET);
     }
 
-    public function testThrowsBaseException()
+    public function testThrowsBaseException(): void
     {
         $this->expectException(\PragmaRX\Google2FA\Exceptions\Google2FAException::class);
 
         $this->throwSecretKeyTooShortException();
     }
 
-    public function testThrowsBaseExceptionContract()
+    public function testThrowsBaseExceptionContract(): void
     {
         $this->expectException(\PragmaRX\Google2FA\Exceptions\Contracts\Google2FA::class);
 
         $this->throwSecretKeyTooShortException();
     }
 
-    public function testThrowsSecretKeyTooShortException()
+    public function testThrowsSecretKeyTooShortException(): void
     {
         $this->expectException(\PragmaRX\Google2FA\Exceptions\SecretKeyTooShortException::class);
 
         $this->throwSecretKeyTooShortException();
     }
 
-    public function testThrowsSecretKeyTooShortExceptionWhenVerifyingCode()
+    public function testThrowsSecretKeyTooShortExceptionWhenVerifyingCode(): void
     {
         $this->expectException(\PragmaRX\Google2FA\Exceptions\SecretKeyTooShortException::class);
 
         $this->google2fa->verify('558854', '', null, 26213400);
     }
 
-    public function testThrowsSecretKeyTooShortExceptionContract()
+    public function testThrowsSecretKeyTooShortExceptionContract(): void
     {
         $this->expectException(\PragmaRX\Google2FA\Exceptions\Contracts\SecretKeyTooShort::class);
 
         $this->throwSecretKeyTooShortException();
     }
 
-    public function testThrowsIncompatibleWithGoogleAuthenticatorExceptionInterface()
+    public function testThrowsIncompatibleWithGoogleAuthenticatorExceptionInterface(): void
     {
         $this->expectException(\PragmaRX\Google2FA\Exceptions\Contracts\IncompatibleWithGoogleAuthenticator::class);
 
         $this->throwIncompatibleWithGoogleAuthenticatorException();
     }
 
-    public function throwSecretKeyTooShortException()
+    public function throwSecretKeyTooShortException(): void
     {
         $this->google2fa->setEnforceGoogleAuthenticatorCompatibility(false);
 
@@ -861,7 +861,7 @@ class Google2FATest extends TestCase
         );
     }
 
-    public function throwIncompatibleWithGoogleAuthenticatorException()
+    public function throwIncompatibleWithGoogleAuthenticatorException(): void
     {
         $this->google2fa
             ->setEnforceGoogleAuthenticatorCompatibility(true)
@@ -877,7 +877,7 @@ class Google2FATest extends TestCase
         );
     }
 
-    public function testOoathTotpThrowsSecretKeyTooShortException()
+    public function testOoathTotpThrowsSecretKeyTooShortException(): void
     {
         $this->expectException(\PragmaRX\Google2FA\Exceptions\SecretKeyTooShortException::class);
 

--- a/tests/Google2FATest.php
+++ b/tests/Google2FATest.php
@@ -883,4 +883,11 @@ class Google2FATest extends TestCase
 
         $this->google2fa->oathTotp('', 0);
     }
+
+    public function testOathTruncateThrowsInvalidHashException(): void
+    {
+        $this->expectException(\PragmaRX\Google2FA\Exceptions\InvalidHashException::class);
+
+        $this->google2fa->oathTruncate('foo');
+    }
 }

--- a/tests/QRCodeTest.php
+++ b/tests/QRCodeTest.php
@@ -17,7 +17,7 @@ class QRCodeTest extends TestCase
         $this->google2fa = new Google2FA();
     }
 
-    public function testCanGetQRCode()
+    public function testCanGetQRCode(): void
     {
         $secretKey = $this->google2fa->generateSecretKey();
 

--- a/tests/helpers.php
+++ b/tests/helpers.php
@@ -1,7 +1,10 @@
 <?php
 
 if (!function_exists('d')) {
-    function d($args)
+    /**
+     * @param array<mixed> $args
+     */
+    function d(array $args): void
     {
         foreach ($args as $arg) {
             var_dump($arg);
@@ -10,7 +13,7 @@ if (!function_exists('d')) {
 }
 
 if (!function_exists('dd')) {
-    function dd()
+    function dd(): void
     {
         d(func_get_args());
 


### PR DESCRIPTION
Update PHPStan level to 9/max with [bleeding edge](https://phpstan.org/blog/what-is-bleeding-edge). You can't go any higher :-) #172 inspired me to do this, to make sure the types are correct throughout the lib.

Native types could be used instead of docblocks if support for older PHP version is dropped, but first I wanted to make sure the lib is on a highest possible PHPStan level to make adding native types a bit safer. Can add them in a next PR once this is merged for example.

This branch is based on #196 branch to make tests run on all PHP versions, probably should be rebased before merging, can take care of that.

I'm not sure what to do with the failing Style CI test that wants me to update a preexisting code like this:
```diff
- exit();
+ exit;
```
I can update it if it looks like what's expected.