### PR TITLE
Allow paragonie/constant_time_encoding version 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.1|^8.0",
-        "paragonie/constant_time_encoding": "^1.0|^2.0"
+        "paragonie/constant_time_encoding": "^1.0|^2.0|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5.15|^8.5|^9.0",


### PR DESCRIPTION
[Supports PHP 8.4 without deprecation warnings for implicit null](https://github.com/paragonie/constant_time_encoding/releases/tag/v3.0.0)