### PR TITLE
Delete trailing comma from parameter list to support PHP 7

### DIFF
--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -393,7 +393,7 @@ class Google2FA
      */
     public function setSecret(
         #[\SensitiveParameter]
-        $secret,
+        $secret
     ) {
         $this->secret = $secret;
     }


### PR DESCRIPTION
This PR resolves an issue with a trailing comma in the setSecret parameter list to support PHP 7.

The commit in the PR is signed (see #200).