### PR TITLE
Increase 2FA key size

### DIFF
--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -123,7 +123,7 @@ class Google2FA
      *
      * @return string
      */
-    public function generateSecretKey($length = 16, $prefix = '')
+    public function generateSecretKey($length = 32, $prefix = '')
     {
         return $this->generateBase32RandomKey($length, $prefix);
     }

--- a/tests/Google2FATest.php
+++ b/tests/Google2FATest.php
@@ -28,11 +28,11 @@ class Google2FATest extends TestCase
 
     public function testGeneratesAValidSecretKey()
     {
-        $this->assertEquals(16, strlen($this->google2fa->generateSecretKey()));
+        $this->assertEquals(32, strlen($this->google2fa->generateSecretKey()));
 
         $this->assertEquals(
-            32,
-            strlen($this->google2fa->generateSecretKey(32))
+            16,
+            strlen($this->google2fa->generateSecretKey(16))
         );
 
         $this->assertStringStartsWith(


### PR DESCRIPTION
When scanning the 2FA codes with FreeOTP it reports that the tokens contain insecure cryptographic parameters. The key is too short. Google authenicator standard is 32 characters.