### PR TITLE
Update PHPStan & Psalm to the latest versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "phpstan/phpstan": "^1.9",
         "phpstan/phpstan-strict-rules": "^1.6",
         "friendsofphp/php-cs-fixer": "^3.0",
-        "vimeo/psalm": "^5.26"
+        "vimeo/psalm": "^5.26|^6.13"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5.15|^8.5|^9.0",
-        "phpstan/phpstan": "^1.9",
-        "phpstan/phpstan-strict-rules": "^1.6",
+        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan-strict-rules": "^2.0",
         "friendsofphp/php-cs-fixer": "^3.0",
         "vimeo/psalm": "^5.26|^6.13"
     },

--- a/psalm.xml
+++ b/psalm.xml
@@ -17,6 +17,7 @@
     </projectFiles>
 
     <issueHandlers>
+        <ClassMustBeFinal errorLevel="suppress" />
         <PropertyNotSetInConstructor>
             <errorLevel type="suppress">
                 <file name="tests/Google2FATest.php" />

--- a/src/Google2FA.php
+++ b/src/Google2FA.php
@@ -140,7 +140,7 @@ class Google2FA
      */
     public function getTimestamp(): int
     {
-        return (int) floor(microtime(true) / $this->keyRegeneration);
+        return (int) (time() / $this->keyRegeneration);
     }
 
     /**

--- a/tests/Google2FATest.php
+++ b/tests/Google2FATest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PragmaRX\Google2FA\Tests;
 
+use Override;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use PragmaRX\Google2FA\Google2FA;
@@ -13,6 +14,7 @@ class Google2FATest extends TestCase
 {
     public Google2FA $google2fa;
 
+    #[Override]
     public function setUp(): void
     {
         $this->google2fa = new Google2FA();

--- a/tests/QRCodeTest.php
+++ b/tests/QRCodeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PragmaRX\Google2FA\Tests;
 
+use Override;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
 use PragmaRX\Google2FA\Google2FA;
@@ -12,6 +13,7 @@ class QRCodeTest extends TestCase
 {
     public Google2FA $google2fa;
 
+    #[Override]
     public function setUp(): void
     {
         $this->google2fa = new Google2FA();


### PR DESCRIPTION
Also:
- ~~Added the `final` keyword to classes~~
- Added `Override` attribute to tests
- Simplified the timestamp calculation instead of typecasting the return values from `microtime()` or the `$keyRegeneration` property