### PR TITLE
Add .github to export-ignore in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,3 +7,4 @@
 /RELICENSED.md export-ignore
 /upgrading.md export-ignore
 /phpstan.neon export-ignore
+/.github export-ignore


### PR DESCRIPTION
Hi! I noticed that the workflow files are in my vendor folder. This will remove the files from distributions.

As a side note, I saw that Symfony does this with `/.git* export-ignore`, but I did not want to make changes to the existing entries like `.gitignore`.

Link to Symfony: https://github.com/symfony/http-foundation/blob/0edbbac68bfa4963b819363ad63a22078d1cd297/.gitattributes#L3